### PR TITLE
Use npm-ci instead of npm-install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /opt/mini-wd
 
 # Copy package.json, package-lock.json to workdir & run npm install to install all dependencies
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 # Copy all files to workdir
 COPY . .


### PR DESCRIPTION
Just a small change to the Dockerfile:

It is actually better to use `npm-ci` instead of `npm-install` in automated and controlled environments because it is way faster and more strict than `npm-install`.

Read more about that here:  
https://docs.npmjs.com/cli/ci